### PR TITLE
add sessionToken option to support temprary security credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Arguments:
   * `region` **required** - The region of your S3 bucket
   * `accessKey` **required** - Your S3 `AWSAccessKeyId`
   * `secretKey` **required** - Your S3 `AWSSecretKey`
+  * `sessionToken` - Your S3 `SessionToken` if you use temprary security credentials
   * `successActionStatus` - HTTP response status if successful, defaults to 201
   * `awsUrl` - [AWS S3 url](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). Defaults to `s3.amazonaws.com`
   * `timeDelta` - Devices time offset from world clock in milliseconds, defaults to 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-aws3",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Pure JavaScript react native library for uploading to AWS S3",
   "author": {
     "name": "Ben Reinhart"

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -63,7 +63,7 @@ export class S3Policy {
 }
 
 const formatPolicyForRequestBody = (base64EncodedPolicy, signature, options) => {
-  return {
+  var body = {
     "key": options.key,
     "acl": options.acl,
     "success_action_status": options.successActionStatus,
@@ -72,12 +72,15 @@ const formatPolicyForRequestBody = (base64EncodedPolicy, signature, options) => 
     "X-Amz-Algorithm": options.algorithm,
     "X-Amz-Date": options.amzDate,
     "Policy": base64EncodedPolicy,
-    "X-Amz-Signature": signature,
+    "X-Amz-Signature": signature
   }
+  if (options.sessionToken)
+    body["x-amz-security-token"] = options.sessionToken
+  return body
 }
 
 const formatPolicyForEncoding = (policy) => {
-  return {
+  var formattedPolicy = {
     "expiration": policy.expirationDate,
     "conditions": [
        {"bucket": policy.bucket},
@@ -90,6 +93,9 @@ const formatPolicyForEncoding = (policy) => {
        {"x-amz-date": policy.amzDate}
     ]
   }
+  if (policy.sessionToken)
+    formattedPolicy.conditions.push({"x-amz-security-token": policy.sessionToken})
+  return formattedPolicy
 }
 
 const getEncodedPolicy = (policy) => {


### PR DESCRIPTION
オリジナルのreact-native-aws3パッケージに、`sessionToken`のサポートを追加します。